### PR TITLE
fix: remove confidence field

### DIFF
--- a/bcut_asr/orm.py
+++ b/bcut_asr/orm.py
@@ -8,13 +8,11 @@ class ASRDataSeg(BaseModel):
         label: str
         start_time: int
         end_time: int
-        confidence: int
     start_time: int
     end_time: int
     transcript: str
     words: list[ASRDataWords]
-    confidence: int
-    
+
     def to_srt_ts(self) -> str:
         '转换为srt时间戳'
         def _conv(ms: int) -> tuple[int ,int, int, int]:


### PR DESCRIPTION
必剪接口升级到 `"version": "1.7.0"` 了，移除了 `confidence` 字段，在 `ASRData.parse_raw` 验证 Model 时会报错