### PR TITLE
add poetry lock to keep poetry.lock update as pyproject.toml change

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ winget install ffmpeg
 ```bash
 git clone https://github.com/SocialSisterYi/bcut-asr
 cd bcut-asr
+poetry lock
 poetry build -f wheel
 pip install dist/bcut_asr-0.0.3-py3-none-any.whl # Example
 ```


### PR DESCRIPTION
```
poetry install
Installing dependencies from lock file

pyproject.toml changed significantly since poetry.lock was last generated. Run `poetry lock [--no-update]` to fix the lock file.      
(base) (bcut-asr-py3.11) PS F:\databuilder\bilibiliQA_databuilder\bcut-asr>
```
