### PR TITLE
Replace sys.exit in main by return. Remove duplication of ffmpeg_render in __init__.py.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,29 +41,29 @@ pip install dist/bcut_asr-0.0.3-py3-none-any.whl # Example
 ### CLI Interface
 
 ```bash
-bcut_asr video.mp4
+bcut-asr video.mp4
 ```
 
 或
 
 ```bash
-bcut_asr video.mp4 subtitle.srt
+bcut-asr video.mp4 subtitle.srt
 ```
 
 或
 
 ```bash
-bcut_asr video.mp4 -f srt - > subtitle.srt
+bcut-asr video.mp4 -f srt - > subtitle.srt
 ```
 
 长音频指定任务状态轮询间隔(秒)，避免接口频繁调用
 
 ```bash
-bcut_asr video.mp4 -f srt -i 30 - > subtitle.srt
+bcut-asr video.mp4 -f srt -i 30 - > subtitle.srt
 ```
 
 ```
-bcut_asr -h
+bcut-asr -h
 usage: bcut-asr [-h] [-f [{srt,json,lrc,txt}]] [-i [1.0]] input [output]
 
 必剪语音识别

--- a/bcut_asr/__init__.py
+++ b/bcut_asr/__init__.py
@@ -16,8 +16,6 @@ from .orm import (
     TaskCreateRspSchema,
 )
 
-from .__main__ import ffmpeg_render
-
 __version__ = "0.0.3"
 
 API_BASE_URL = "https://member.bilibili.com/x/bcut/rubick-interface"
@@ -38,6 +36,16 @@ SUPPORT_SOUND_FORMAT = Literal["flac", "aac", "m4a", "mp3", "wav"]
 
 INFILE_FMT = ["flac", "aac", "m4a", "mp3", "wav"]
 OUTFILE_FMT = ["srt", "json", "lrc", "txt"]
+
+
+def ffmpeg_render(media_file: str) -> bytes:
+    "提取视频伴音并转码为aac格式"
+    out, err = (
+        ffmpeg.input(media_file, v="warning")
+        .output("pipe:", ac=1, format="adts")
+        .run(capture_stdout=True)
+    )
+    return out
 
 
 def run_everywhere(argg):

--- a/bcut_asr/__init__.py
+++ b/bcut_asr/__init__.py
@@ -16,6 +16,8 @@ from .orm import (
     TaskCreateRspSchema,
 )
 
+from .__main__ import ffmpeg_render
+
 __version__ = "0.0.3"
 
 API_BASE_URL = "https://member.bilibili.com/x/bcut/rubick-interface"
@@ -36,16 +38,6 @@ SUPPORT_SOUND_FORMAT = Literal["flac", "aac", "m4a", "mp3", "wav"]
 
 INFILE_FMT = ["flac", "aac", "m4a", "mp3", "wav"]
 OUTFILE_FMT = ["srt", "json", "lrc", "txt"]
-
-
-def ffmpeg_render(media_file: str) -> bytes:
-    "提取视频伴音并转码为aac格式"
-    out, err = (
-        ffmpeg.input(media_file, v="warning")
-        .output("pipe:", ac=1, format="adts")
-        .run(capture_stdout=True)
-    )
-    return out
 
 
 def run_everywhere(argg):
@@ -162,6 +154,7 @@ class APIError(Exception):
 
 class BcutASR:
     "必剪 语音识别接口"
+
     session: requests.Session
     sound_name: str
     sound_bin: bytes
@@ -177,7 +170,7 @@ class BcutASR:
     task_id: str
 
     def __init__(self, file: Optional[str | PathLike] = None) -> None:
-        self.session = requests.Session()
+        self.session: requests.Session = requests.Session()
         self.task_id = None
         self.__etags = []
         if file:
@@ -229,7 +222,7 @@ class BcutASR:
         code = resp["code"]
         if code:
             raise APIError(code, resp["message"])
-        resp_data = ResourceCreateRspSchema.parse_obj(resp["data"])
+        resp_data = ResourceCreateRspSchema.model_validate(resp["data"])
         self.__in_boss_key = resp_data.in_boss_key
         self.__resource_id = resp_data.resource_id
         self.__upload_id = resp_data.upload_id

--- a/bcut_asr/__main__.py
+++ b/bcut_asr/__main__.py
@@ -121,7 +121,7 @@ def main():
                     logging.info(f"识别中 {task_resp.remark}")
                 case ResultStateEnum.ERROR:
                     logging.error(f"识别失败 {task_resp.remark}")
-                    sys.exit(-1)
+                    return -1
                 case ResultStateEnum.COMPLETE:
                     logging.info(f"识别成功")
                     outfile_name = f"{infile_name.rsplit('.', 1)[-2]}.{outfile_fmt}"


### PR DESCRIPTION
我把`main`里面一个`sys.exit(-1)`改成了`return -1`。我还去掉了`\_\_init\_\_.py`里`ffmpeg\_render`的重复定义。我还发现`run\_everywhere`和`main`内容几乎一样，为什么要写两次几乎一样的函数呢？

